### PR TITLE
Fix: adjust the overlay opacity

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -65,7 +65,7 @@ body {
     left: 0;
     height: 100%;
     width: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(0, 0, 0, 0.25);
 }
 /* end of copied Code Institute css code from the Whiskey Drop project */
 


### PR DESCRIPTION
Issue #56 
Changed the rgba opacity value of the overlay from 0.5 to 0.25 to brighten the image