### PR TITLE
60 callout image size

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -126,7 +126,7 @@ body {
 .testimonial-carousel {
 /* Background image css code copied from the Code Institute Whiskey Drop project*/
     background-color: transparent;
-    background: url('../images/above-the-clouds.jpg') no-repeat bottom right fixed;
+    background: url('../images/above-the-clouds.jpg') no-repeat center fixed;
     -webkit-background-size: cover;
     -moz-background-size: cover;
     -o-background-size: cover;
@@ -245,7 +245,7 @@ body {
 /* -------------------------------------Media Queries */
 /* -------------------------------------Responsive Design - TABLET*/
 
-  @media screen and (max-width: 943px) {
+@media screen and (max-width: 943px) {
     .jumbotron h1 {
         font-family: 'Arapey', serif;
         font-size: 2.5rem;
@@ -253,4 +253,74 @@ body {
     .jumbotron p {
         font-size: 1.2rem;
     }
-  }
+}
+
+/* Apple devices do not support background-attachment: fixed; displaying background images incorrectly*/
+/* These media queries are a workaround to try to fix device specific display issues rather than using */
+/* background-attachment: scroll; for all devices */
+
+/* -------------------------------------iPadPro Optional */
+/* -------------------------------------Portrait */
+
+@media only screen 
+    and (min-width: 1024px)
+    and (max-width: 1024px)
+    and (orientation: portrait) {
+        .callout-container {
+            background: url('../images/aircraft-hangar-lg.jpg') no-repeat center;
+            background-size: 100%
+        }
+        .testimonial-carousel {
+            background: url('../images/above-the-clouds.jpg') no-repeat center;
+            background-size: 100%
+    }
+}
+
+/* -------------------------------------Landscape */
+
+  @media only screen 
+    and (min-width: 1366px)
+    and (max-width: 1366px)
+    and (orientation: landscape) {
+        .callout-container {
+            background: url('../images/aircraft-hangar-lg.jpg') no-repeat center;
+            background-size: 100%
+        }
+        .testimonial-carousel {
+            background: url('../images/above-the-clouds.jpg') no-repeat center;
+            background-size: 100%
+        }
+    }
+
+/* -------------------------------------iPhone XS Max Optional */
+/* -------------------------------------Portrait */
+
+@media only screen 
+    and (min-width: 414px)
+    and (max-width: 414px)
+    and (orientation: portrait) {
+        .callout-container {
+            background: url('../images/aircraft-hangar-lg.jpg') no-repeat center scroll;
+            background-size: 100%
+        }
+        .testimonial-carousel {
+            background: url('../images/above-the-clouds.jpg') no-repeat center scroll;
+            background-size: 100%
+    }
+}
+
+/* -------------------------------------Landscape */
+
+  @media only screen 
+    and (min-width: 896px)
+    and (max-width: 896px)
+    and (orientation: landscape) {
+        .callout-container {
+            background: url('../images/aircraft-hangar-lg.jpg') no-repeat center scroll;
+            background-size: 100%
+        }
+        .testimonial-carousel {
+            background: url('../images/above-the-clouds.jpg') no-repeat center scroll;
+            background-size: 100%
+        }
+    }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -22,7 +22,7 @@ body {
 
 
 /* -------------------------------------MAIN BODY STYLING */
-/* -------------------------------------Callout */
+/* -------------------------------------Homepage Callout Section */
 
 .callout-container {
 /* Background image css code copied from the Code Institute Whiskey Drop project*/
@@ -43,6 +43,43 @@ body {
     padding: 20px;
 }
 
+/* Opaque Overlay css code copied from the Code Institute Whiskey Drop project*/ 
+.opaque-overlay {
+    position: absolute;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
+    background-color: rgba(0, 0, 0, 0.25);
+}
+/* end of copied Code Institute css code from the Whiskey Drop project */
+
+/* -------------------------------------Our Services Hero Image Section */
+
+.our-services-hero-container {
+    height:600px;
+    width: 100%;
+    background: url("http://codeinstitute.s3.amazonaws.com/FundamentalsProjects/HTML-CSS/main-image.png") no-repeat center center;
+}
+
+/* -------------------------------------About Us Hero Image Section */
+
+.about-us-hero-container {
+    height:600px;
+    width: 100%;
+    background: url("http://codeinstitute.s3.amazonaws.com/FundamentalsProjects/HTML-CSS/main-image.png") no-repeat center center;
+}
+
+/* -------------------------------------Contact Us Hero Image Section */
+
+.contact-us-hero-container {
+    height:600px;
+    width: 100%;
+    background: url("http://codeinstitute.s3.amazonaws.com/FundamentalsProjects/HTML-CSS/main-image.png") no-repeat center center;
+}
+
+/* -------------------------------------Jumbotron */
+
 .jumbotron {
     background: none;
 }
@@ -62,6 +99,8 @@ body {
     text-shadow: 0 0 4px #000000;
 }
 
+/* -------------------------------------Buttons */
+
 .contact-btn {
     color: #444;
     font-weight: bold;
@@ -75,18 +114,6 @@ body {
     background-color: #444;
     border: 1px solid #444;
 }
-
-/* Opaque Overlay css code copied from the Code Institute Whiskey Drop project*/ 
-.opaque-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    background-color: rgba(0, 0, 0, 0.25);
-}
-/* end of copied Code Institute css code from the Whiskey Drop project */
-
 
 /* -------------------------------------Card Deck */
 


### PR DESCRIPTION
- Refactored CSS grouping into more meaningful groups for readbility
- Fix for Issue #60 Add media queries for device specific displays as a temporary workaround
  - Apple devices do not support background-attachment: fixed; property
  - iPad and iPhone specific media queries created to change the property from FIXED to SCROLL to provide a temporary workaround