### PR TITLE
Fix: issue 71 error 405 not allowed

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
 
                 <!-- Modal Body Contact Us Form -->
                 <div class="modal-body">
-                    <form method="post" action="/confirmation.html">
+                    <form action="confirmation.html">
                         <div class="form-group">
                             <label for="username"><i class="fas fa-user"></i>  Name</label>
                             <input type="text" class="form-control" id="username" name="username" placeholder="Enter name" required>


### PR DESCRIPTION
Problem traced to the form attribute  method='post' on line 122 causing the error message 405 Method Not Allowed
Form attribute deleted and the confirmation.html page now opens correctly when the send button is clicked.

Issue #71 