### PR TITLE
Fix: Responsive jumbotron logo + text

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -35,7 +35,7 @@ body {
     justify-content: center;
     position: relative;
 /* end of copied Code Institute css code from the Whiskey Drop project */
-    font-size: 1.1rem;
+    /* font-size: 1.1rem; */
     min-height: 200px;
     padding: 20px;
 }
@@ -136,11 +136,17 @@ body {
 }
 
 .jumbotron p {
-    font-size: 1.8rem;
+    font-size: 1.7rem;
     font-weight: 500;
     color: white;
     text-shadow: 0 0 4px #000000;
     margin: 20px 0;
+}
+
+.jumbotron-logo img {
+    max-width: 100%;
+    width: 575px;
+    height: auto;
 }
 
 /* -------------------------------------Buttons */
@@ -390,8 +396,18 @@ body {
 
 @media screen and (max-width: 943px) {
     .jumbotron h1 {
-        font-family: 'Arapey', serif;
-        font-size: 2.5rem;
+        font-size: 5rem;
+    }
+    .jumbotron p {
+        font-size: 1.4rem;
+    }
+}
+
+/* -------------------------------------Responsive Design - MOBILE*/
+
+@media screen and (max-width: 430px) {
+    .jumbotron h1 {
+        font-size: 3rem;
     }
     .jumbotron p {
         font-size: 1.2rem;

--- a/confirmation.html
+++ b/confirmation.html
@@ -38,12 +38,8 @@
             <div class="col-12" data-toggle="modal" data-target="#confirmation">
                 <section class="jumbotron text-center">
                     <!-- Show the logo on tablet displays and larger only-->
-                    <div class="d-none d-sm-block">
-                        <img src="assets/images/logo-image-reverse.png" width="400" height="200" class="d-inline-block align-top" alt="" loading="lazy">
-                    </div>
-                    <!-- Show the Company name in text on mobile devices -->
-                    <div class="col-12 d-sm-none">
-                        <h1>Aviation Consultancy LLC</h1>
+                    <div class="jumbotron-logo">
+                        <img src="assets/images/logo-image-reverse.png" class="d-inline-block" alt="Aviation Consultancy LLC Logo image" loading="lazy">
                     </div>
                     <h1>Thank you!</h1>
                     <hr class="block-divider-sm-white">

--- a/index.html
+++ b/index.html
@@ -55,12 +55,8 @@
             <div class="col-12">
                 <section class="jumbotron text-center">
                     <!-- Show the logo on tablet displays and bigger only-->
-                    <div class="d-none d-sm-block">
-                        <img src="assets/images/logo-image-reverse.png" width="575" height="285" class="d-inline-block align-top" alt="" loading="lazy">
-                    </div>
-                    <!-- Show the COmpany name in text on mobile devices -->
-                    <div class="col-12 d-sm-none">
-                        <h1>Aviation Consultancy LLC</h1>
+                    <div class="jumbotron-logo">
+                        <img src="assets/images/logo-image-reverse.png" class="d-inline-block" alt="Aviation COnsultancy LLC Logo Image" loading="lazy">
                     </div>
                     <p>
                         If you are looking for data management expertise<br>


### PR DESCRIPTION
Remove media breakpoints to swap jumbotron logo to text on mobile displays
Add .jumbotron-logo class to make logo resize responsively on Homepage and confirmation page