### PR TITLE
Fix: W3C HTML + CSS validator errors

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -268,7 +268,7 @@
             </div>
             <div class="col-12 col-lg-4 mb-2 sitemap">
                 <h4>Sitemap</h4>
-              <h5><i class="fas fa-sitemap"></i></h5>
+                <span><i class="fas fa-sitemap"></i></span>
                 <ul class="list-unstyled">
                     <li>
                         <a href="index.html"><span>Home</span></a>
@@ -292,7 +292,7 @@
             </div>
             <div class="col-12 col-lg-4 contact-address">
                 <h4>Contact</h4>
-                <h5><i class="fas fa-map-marker-alt"></i></h5>
+                <span><i class="fas fa-map-marker-alt"></i></span>
                 <p>
                     Aviation Consultancy LLC<br>
                     World Business Centre 3, Newall Road,<br>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -255,7 +255,8 @@ body {
 /* -------------------------------------Contact Us Page */
 /* -------------------------------------Contact Us cards */
 
-.icon-bg h2 i {
+.icon-bg span i {
+    font-size: 2rem;
     height: 70px;
     width: 70px;
     padding: 20px 0;
@@ -411,6 +412,12 @@ body {
 
 .icon-bg-sm ul li a i:hover {
     background-color: #444;
+}
+
+.sitemap span i,
+.contact-address span i {
+    font-size: 1.3rem;
+    font-weight: bolder;
 }
 
 .sitemap ul li a {

--- a/contact-us.html
+++ b/contact-us.html
@@ -70,7 +70,7 @@
         <div class="container-fluid mx-auto mb-5">
             <div class="row">
                 <div class="col-sm-12 col-md-2 offset-md-3 text-center icon-bg contact-us-card mb-3">
-                    <h2><i class="fas fa-map-marker-alt"></i></h2>
+                    <span><i class="fas fa-map-marker-alt"></i></span>
                     <h3><strong>Address</strong></h3>
                     <p>
                         Aviation Consultancy LLC<br>
@@ -81,7 +81,7 @@
                     </p>
                 </div>
                 <div class="col-sm-12 col-md-2 text-center icon-bg contact-us-card mb-3">
-                    <h2><i class="fas fa-phone-alt"></i></h2>
+                    <span><i class="fas fa-phone-alt"></i></span>
                     <h3><strong>Call Center</strong></h3>
                     <p>
                         Please call us to discuss your next project with one of our consultants.
@@ -91,7 +91,7 @@
                     </p>
                 </div>
                 <div class="col-sm-12 col-md-2 text-center contact-us-card icon-bg">
-                    <h2><i class="fas fa-envelope"></i></h2>
+                    <span><i class="fas fa-envelope"></i></span>
                     <h3><strong>Support</strong></h3>
                     <p>
                         Please feel free to send us an email or to use our electronic ticketing system
@@ -280,7 +280,7 @@
             </div>
             <div class="col-12 col-lg-4 mb-2 sitemap">
                 <h4>Sitemap</h4>
-              <h5><i class="fas fa-sitemap"></i></h5>
+                <span><i class="fas fa-sitemap"></i></span>
                 <ul class="list-unstyled">
                     <li>
                         <a href="index.html"><span>Home</span></a>
@@ -304,7 +304,7 @@
             </div>
             <div class="col-12 col-lg-4 contact-address">
                 <h4>Contact</h4>
-                <h5><i class="fas fa-map-marker-alt"></i></h5>
+                <span><i class="fas fa-map-marker-alt"></i></span>
                 <p>
                     Aviation Consultancy LLC<br>
                     World Business Centre 3, Newall Road,<br>

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
             <div class="opaque-overlay">&nbsp;</div>
             <div id="callout-jumbotron" class="row">
                 <div class="col-12">
-                    <section class="jumbotron text-center">
+                    <div class="jumbotron text-center">
                         <!-- Show the logo on tablet displays and bigger only-->
                         <div class="jumbotron-logo">
                             <img src="assets/images/logo-image-reverse.png" class="d-inline-block" alt="Aviation COnsultancy LLC Logo Image" loading="lazy">
@@ -66,7 +66,7 @@
                             we can deliver the support and assurance you need.
                         </p>
                         <button type="button" class="btn btn-lg pill-btn" data-toggle="modal" data-target="#contactUsModal">CONTACT US TODAY</button>
-                    </section>
+                    </div>
                 </div>
             </div>
         </div>
@@ -281,7 +281,7 @@
             </div>
             <div class="col-12 col-lg-4 mb-2 sitemap">
                 <h4>Sitemap</h4>
-              <h5><i class="fas fa-sitemap"></i></h5>
+                <span><i class="fas fa-sitemap"></i></span>
                 <ul class="list-unstyled">
                     <li>
                         <a href="index.html"><span>Home</span></a>
@@ -305,7 +305,7 @@
             </div>
             <div class="col-12 col-lg-4 contact-address">
                 <h4>Contact</h4>
-                <h5><i class="fas fa-map-marker-alt"></i></h5>
+                <span><i class="fas fa-map-marker-alt"></i></span>
                 <p>
                     Aviation Consultancy LLC<br>
                     World Business Centre 3, Newall Road,<br>

--- a/our-services.html
+++ b/our-services.html
@@ -222,7 +222,7 @@
             </div>
             <div class="col-12 col-lg-4 mb-2 sitemap">
                 <h4>Sitemap</h4>
-              <h5><i class="fas fa-sitemap"></i></h5>
+                <span><i class="fas fa-sitemap"></i></span>
                 <ul class="list-unstyled">
                     <li>
                         <a href="index.html"><span>Home</span></a>
@@ -246,7 +246,7 @@
             </div>
             <div class="col-12 col-lg-4 contact-address">
                 <h4>Contact</h4>
-                <h5><i class="fas fa-map-marker-alt"></i></h5>
+                <span><i class="fas fa-map-marker-alt"></i></span>
                 <p>
                     Aviation Consultancy LLC<br>
                     World Business Centre 3, Newall Road,<br>

--- a/privacy.html
+++ b/privacy.html
@@ -466,7 +466,7 @@
             </div>
             <div class="col-12 col-lg-4 mb-2 sitemap">
                 <h4>Sitemap</h4>
-              <h5><i class="fas fa-sitemap"></i></h5>
+                <span><i class="fas fa-sitemap"></i></span>
                 <ul class="list-unstyled">
                     <li>
                         <a href="index.html"><span>Home</span></a>
@@ -490,7 +490,7 @@
             </div>
             <div class="col-12 col-lg-4 contact-address">
                 <h4>Contact</h4>
-                <h5><i class="fas fa-map-marker-alt"></i></h5>
+                <span><i class="fas fa-map-marker-alt"></i></span>
                 <p>
                     Aviation Consultancy LLC<br>
                     World Business Centre 3, Newall Road,<br>

--- a/terms-and-conditions.html
+++ b/terms-and-conditions.html
@@ -367,7 +367,7 @@
             </div>
             <div class="col-12 col-lg-4 mb-2 sitemap">
                 <h4>Sitemap</h4>
-              <h5><i class="fas fa-sitemap"></i></h5>
+                <span><i class="fas fa-sitemap"></i></span>
                 <ul class="list-unstyled">
                     <li>
                         <a href="index.html"><span>Home</span></a>
@@ -391,7 +391,7 @@
             </div>
             <div class="col-12 col-lg-4 contact-address">
                 <h4>Contact</h4>
-                <h5><i class="fas fa-map-marker-alt"></i></h5>
+                <span><i class="fas fa-map-marker-alt"></i></span>
                 <p>
                     Aviation Consultancy LLC<br>
                     World Business Centre 3, Newall Road,<br>


### PR DESCRIPTION
W3c HTML & CSS Validator check errors:
- Errors were related to FontAwesome icons nested within heading tags stating there were empty headings
- Replaced all heading tags with <span> tags as inline elements. 
- Most changes were in the footer sitemap and contact sections
- Contact Us page Address, Call Centre and Support card icons were updated
- Changed the affected css classes to replace the old tags with the spans.