### PR TITLE
Fix: Testimonials carousel bottom margin missing

### DIFF
--- a/about-us.html
+++ b/about-us.html
@@ -168,7 +168,7 @@
         <!-- /Meet The Team Cards Cards-->
 
         <!-- Testimonials Carousel -->
-        <div id="testimonialCarousel" class="carousel slide testimonial-carousel" data-ride="carousel">
+        <div id="testimonialCarousel" class="carousel slide testimonial-carousel mb-5" data-ride="carousel">
             <div class="carousel-inner">
                 <div class="carousel-item active" data-interval="7000">
                     <div class="col-sm-6 offset-sm-3">

--- a/our-services.html
+++ b/our-services.html
@@ -119,7 +119,7 @@
         <!-- /Features Cards-->
 
         <!-- Testimonials Carousel -->
-        <div id="testimonialCarousel" class="carousel slide testimonial-carousel" data-ride="carousel">
+        <div id="testimonialCarousel" class="carousel slide testimonial-carousel mb-5" data-ride="carousel">
             <div class="carousel-inner">
                 <!-- Testimonial Page 1 -->
                 <div class="carousel-item active" data-interval="7000">


### PR DESCRIPTION
Found that Bootstrap class .mb-5 was missing from the main carousel div classes for both pages
Add in mb-5 class and both pages now work as expected

ref issue #94 