### PR TITLE
Fix: issue #97 contact us email wrapping

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -269,7 +269,7 @@ body {
 /* -------------------------------------Contact Us Page */
 /* -------------------------------------Contact Us cards */
 
-.icon-bg span i {
+.icon-bg>span>i {
     font-size: 2rem;
     height: 70px;
     width: 70px;
@@ -291,6 +291,10 @@ body {
 
 .contact-us-card p a:hover {
     color: #000;
+}
+
+.small-email {
+    display: none;
 }
 
 /* -------------------------------------Google Maps iframe */
@@ -472,7 +476,7 @@ body {
 /* in portrait and landscape modes */
 
 
-@media screen and (max-width: 1120px) {
+@media screen and (max-width: 1366px) {
     .callout-container {
         background: url('../images/aircraft-hangar-960w.jpg') no-repeat center scroll;
         background-size: cover;
@@ -495,3 +499,23 @@ body {
     }
 }
 
+/* -------------------------------------Responsive Design - Contact Us Support email */
+/* long email addresses wrap to the next line as the page width reduces -*/
+/* these media queries attempt to improve the design by replacing them with smaller email links */
+/* until the bootstrap grid resizes to a single column */
+
+@media screen and (max-width: 1192px) and (min-width: 767px) {
+    .large-email {
+        display: none;
+    }
+    .small-email {
+        display: inline-block
+    }
+}
+
+/* return the email address to normal once the page reaches col-12 grid layout on mobile displays */
+@media screen and (max-width: 767px) {
+    .small-email {
+        display: none;
+    }
+}

--- a/contact-us.html
+++ b/contact-us.html
@@ -67,9 +67,9 @@
         <!-- /Hero Image -->
 
         <!-- Contact Us Section-->
-        <div class="container-fluid mx-auto mb-5">
+        <div class="container-fluid mb-5">
             <div class="row">
-                <div class="col-sm-12 col-md-2 offset-md-3 text-center icon-bg contact-us-card mb-3">
+                <div class="col-sm-12 col-md-3 text-center icon-bg contact-us-card mx-auto mb-3">
                     <span><i class="fas fa-map-marker-alt"></i></span>
                     <h3><strong>Address</strong></h3>
                     <p>
@@ -80,7 +80,7 @@
                         <strong>United Kingdom.</strong>
                     </p>
                 </div>
-                <div class="col-sm-12 col-md-2 text-center icon-bg contact-us-card mb-3">
+                <div class="col-sm-12 col-md-3 text-center icon-bg contact-us-card mx-auto mb-3">
                     <span><i class="fas fa-phone-alt"></i></span>
                     <h3><strong>Call Center</strong></h3>
                     <p>
@@ -90,16 +90,23 @@
                         <strong>+44 (0)208 042 200888</strong>
                     </p>
                 </div>
-                <div class="col-sm-12 col-md-2 text-center contact-us-card icon-bg">
+                <div class="col-sm-12 col-md-3 text-center contact-us-card mx-auto icon-bg">
                     <span><i class="fas fa-envelope"></i></span>
                     <h3><strong>Support</strong></h3>
                     <p>
                         Please feel free to send us an email or to use our electronic ticketing system
                     </p>
-                    <p>
-                        <a href="mailto:info@aviation-consulting-llc.com"><strong>info@aviation-consulting-llc.com</strong></a><br>
-                        <a href="mailto:contact@aviation-consulting-llc.com"><strong>contact@aviation-consulting-llc.com</strong></a>
+                    <!-- long email addresses wrap to the next line as the page width reduces -->
+                    <!-- media queries attempt to improve the design by replacing them with smaller email links --> 
+                    <p class="large-email">
+                        <span><a href="mailto:info@aviation-consulting-llc.com"><strong>info@aviation-consulting-llc.com</strong></a></span><br>
+                        <span><a href="mailto:support@aviation-consulting-llc.com"><strong>support@aviation-consulting-llc.com</strong></a></span>
                     </p>
+                    <p class="small-email">
+                        <span><a href="mailto:info@aviation-consulting-llc.com"><strong><i class="fas fa-envelope"></i> Info email</strong></a></span><br>
+                        <span><a href="mailto:support@aviation-consulting-llc.com"><strong><i class="fas fa-envelope"></i> Support email</strong></a></span>
+                    </p>
+
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Fix and close issue #97 
- Add in .small-email and .large-email classes for different email size formats
- Add in small email address links with envelope icons
- Add in CSS media queries to swap between large and small email formats at 767px to 1192px display widths
- resize the 3 column widths from col-md-2 to col-md-3 to give the text more space before resizing
  - this gave an odd number column count so .offset-md-2 no longer worked correctly
  - needed the class .mx-auto adding to each column div to center the 3 columns and removed the offset class